### PR TITLE
Added support for empty 1-0:99.97.0 object, solved linker error (mult…

### DIFF
--- a/logmsg.h
+++ b/logmsg.h
@@ -27,12 +27,12 @@ typedef struct msglogger_struct {
 	
 } messagelogger;
 
-messagelogger logger;
+static messagelogger logger;
 
-static inline void init_msglogger() {
+static void init_msglogger() {
 		logger.logfile_name = NULL;
 		logger.logfile = stdout;
-		logger.loglevel = LL_NORMAL;
+		logger.loglevel = LL_VERBOSE;
 }
 
 

--- a/p1-lib.c
+++ b/p1-lib.c
@@ -110,6 +110,7 @@ size_t read_telegram (int fd, uint8_t *buf, size_t bufsize, size_t maxfailbytes)
 
 int telegram_parser_open (telegram_parser *obj, char *infile, size_t bufsize, int timeout, char *dumpfile)
 {
+	init_msglogger();
 	if (obj == NULL) {
 		return -1;
 	}

--- a/p1-parser.rl
+++ b/p1-parser.rl
@@ -520,6 +520,7 @@ long long int TST_to_time (struct parser *fsm, int arg_idx) {
 	pfail = '0-0:96.7.21(' uinteger ')' crlf @pfail; 
 	longpfail = '0-0:96.7.9(' uinteger ')' crlf @longpfail; 
 	
+	pfailevents_empty = '1-0:99.97.0()' crlf @pfailevents @clearargs;
 	pfailevents = '1-0:99.97.0(' uinteger ')' @pfailevents @clearargs;	# Power failure events
 	pfailevent = tstval '(' uinteger unit ')' @pfailevent @clearargs;		# Single power failure event
 	pfaileventlog = pfailevents '(0-0:96.7.19)'? pfailevent* crlf;	# Power failure event log, with zero or more events
@@ -586,7 +587,7 @@ long long int TST_to_time (struct parser *fsm, int arg_idx) {
 	power_object = P_in | P_out | P_in_L1 | P_out_L1 | P_in_L2 | P_out_L2 | P_in_L3 | P_out_L3 | P_threshold;
 	current_object = I_L1 | I_L2 | I_L3;
 	voltage_object = V_L1 | V_L2 | V_L3;
-	power_quality_object = pfail | longpfail | pfaileventlog | V_sags_L1 | V_swells_L1 | V_sags_L2 | V_swells_L2 | V_sags_L3 | V_swells_L3;
+	power_quality_object = pfail | longpfail | pfailevents_empty | pfaileventlog | V_sags_L1 | V_swells_L1 | V_sags_L2 | V_swells_L2 | V_sags_L3 | V_swells_L3;
 	mbusdev_object = dev_type | dev_id | dev_counter | dev_valve | dev_counter_timeseries | dev_counter_cold_timeseries;
 	slavedev_legacy_object = gas_id_old | gas_count_old;
 	message_object = textmsgcodes | textmsg | textmsgcodes_empty | textmsg_empty;
@@ -607,6 +608,8 @@ long long int TST_to_time (struct parser *fsm, int arg_idx) {
 
 void parser_init( struct parser *fsm )
 {
+	init_msglogger();
+
 	int arg;
 	
 	fsm->buflen = 0;


### PR DESCRIPTION
… defs) at gcc >= 10

The parser failed to parse an empty object of type Power Failure Event Log (“1-0:99.97.0()\r\n”) correctly resulting in an “Error while parsing” massage. This object is send by the DSMR 5.0 smart meter of type ISKRA AM550 which is installed at my premises. Support has been added for this empty object resulting in an “Power failure events: 0” message.

The code failed to build with gcc version >= 10 due to a linker error regarding multiple defenitions of  global variable “logger” (logmsg.h). This issue could be solved by adding -fcommon to the gcc flags, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85678 for background on this. A more neat way to deal with this issue is (imho) to make “logger” static. This requires “logger” to be initialized within every translation unit, thus an init_msglogger() call has been added to every translation unit’s init function, i.e. telegram_parser_open() in p1-lib.c and parser_init() in p1-parser.rl.